### PR TITLE
fix: preserve JsonEditor initial value on serve 

### DIFF
--- a/docs/apidocs/panelini/panelini.md
+++ b/docs/apidocs/panelini/panelini.md
@@ -13,8 +13,8 @@
 :titlesonly:
 :maxdepth: 3
 
-panelini.panels
 panelini.components
+panelini.panels
 ```
 
 ## Submodules

--- a/docs/apidocs/panelini/panelini.panels.ai.plot.tools.md
+++ b/docs/apidocs/panelini/panelini.panels.ai.plot.tools.md
@@ -13,7 +13,7 @@
 :titlesonly:
 :maxdepth: 1
 
-panelini.panels.ai.plot.tools.plot_tools
-panelini.panels.ai.plot.tools.osw_tools
 panelini.panels.ai.plot.tools.osw_plot_tools
+panelini.panels.ai.plot.tools.osw_tools
+panelini.panels.ai.plot.tools.plot_tools
 ```

--- a/docs/apidocs/panelini/panelini.panels.ai.plot.utils.md
+++ b/docs/apidocs/panelini/panelini.panels.ai.plot.utils.md
@@ -13,6 +13,6 @@
 :titlesonly:
 :maxdepth: 1
 
-panelini.panels.ai.plot.utils.sandbox
 panelini.panels.ai.plot.utils.osw_env
+panelini.panels.ai.plot.utils.sandbox
 ```

--- a/docs/apidocs/panelini/panelini.panels.md
+++ b/docs/apidocs/panelini/panelini.panels.md
@@ -16,4 +16,5 @@
 panelini.panels.ai
 panelini.panels.jsoneditor
 panelini.panels.visnetwork
+panelini.panels.wunderbaum
 ```

--- a/docs/apidocs/panelini/panelini.panels.visnetwork.md
+++ b/docs/apidocs/panelini/panelini.panels.visnetwork.md
@@ -14,6 +14,6 @@
 :maxdepth: 1
 
 panelini.panels.visnetwork.graph_detail_tool
-panelini.panels.visnetwork.visnetwork
 panelini.panels.visnetwork.utils
+panelini.panels.visnetwork.visnetwork
 ```

--- a/docs/apidocs/panelini/panelini.panels.wunderbaum.md
+++ b/docs/apidocs/panelini/panelini.panels.wunderbaum.md
@@ -1,0 +1,17 @@
+# {py:mod}`panelini.panels.wunderbaum`
+
+```{py:module} panelini.panels.wunderbaum
+```
+
+```{autodoc2-docstring} panelini.panels.wunderbaum
+:allowtitles:
+```
+
+## Submodules
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
+panelini.panels.wunderbaum.wunderbaum
+```

--- a/docs/apidocs/panelini/panelini.panels.wunderbaum.wunderbaum.md
+++ b/docs/apidocs/panelini/panelini.panels.wunderbaum.wunderbaum.md
@@ -1,0 +1,248 @@
+# {py:mod}`panelini.panels.wunderbaum.wunderbaum`
+
+```{py:module} panelini.panels.wunderbaum.wunderbaum
+```
+
+```{autodoc2-docstring} panelini.panels.wunderbaum.wunderbaum
+:allowtitles:
+```
+
+## Module Contents
+
+### Classes
+
+````{list-table}
+:class: autosummary longtable
+:align: left
+
+* - {py:obj}`Wunderbaum <panelini.panels.wunderbaum.wunderbaum.Wunderbaum>`
+  - ```{autodoc2-docstring} panelini.panels.wunderbaum.wunderbaum.Wunderbaum
+    :summary:
+    ```
+````
+
+### Data
+
+````{list-table}
+:class: autosummary longtable
+:align: left
+
+* - {py:obj}`bundled_assets_dir <panelini.panels.wunderbaum.wunderbaum.bundled_assets_dir>`
+  - ```{autodoc2-docstring} panelini.panels.wunderbaum.wunderbaum.bundled_assets_dir
+    :summary:
+    ```
+````
+
+### API
+
+````{py:data} bundled_assets_dir
+:canonical: panelini.panels.wunderbaum.wunderbaum.bundled_assets_dir
+:value: >
+   None
+
+```{autodoc2-docstring} panelini.panels.wunderbaum.wunderbaum.bundled_assets_dir
+```
+
+````
+
+`````{py:class} Wunderbaum(source: typing.Optional[list[dict[str, typing.Any]]] = None, columns: typing.Optional[list[dict[str, typing.Any]]] = None, options: typing.Optional[dict[str, typing.Any]] = None, types: typing.Optional[dict[str, typing.Any]] = None, context_menu_items: typing.Optional[list[dict[str, typing.Any]]] = None, tree_event_callback: typing.Optional[typing.Callable[[str, dict[str, typing.Any]], None]] = None, lazy_load_callback: typing.Optional[typing.Callable[[str, dict[str, typing.Any]], list[dict[str, typing.Any]]]] = None, file_drop_callback: typing.Optional[typing.Callable[[dict[str, typing.Any]], None]] = None, **params: typing.Any)
+:canonical: panelini.panels.wunderbaum.wunderbaum.Wunderbaum
+
+Bases: {py:obj}`panel.custom.AnyWidgetComponent`
+
+```{autodoc2-docstring} panelini.panels.wunderbaum.wunderbaum.Wunderbaum
+```
+
+```{rubric} Initialization
+```
+
+```{autodoc2-docstring} panelini.panels.wunderbaum.wunderbaum.Wunderbaum.__init__
+```
+
+````{py:attribute} source
+:canonical: panelini.panels.wunderbaum.wunderbaum.Wunderbaum.source
+:value: >
+   'List(...)'
+
+```{autodoc2-docstring} panelini.panels.wunderbaum.wunderbaum.Wunderbaum.source
+```
+
+````
+
+````{py:attribute} columns
+:canonical: panelini.panels.wunderbaum.wunderbaum.Wunderbaum.columns
+:value: >
+   'List(...)'
+
+```{autodoc2-docstring} panelini.panels.wunderbaum.wunderbaum.Wunderbaum.columns
+```
+
+````
+
+````{py:attribute} options
+:canonical: panelini.panels.wunderbaum.wunderbaum.Wunderbaum.options
+:value: >
+   'Dict(...)'
+
+```{autodoc2-docstring} panelini.panels.wunderbaum.wunderbaum.Wunderbaum.options
+```
+
+````
+
+````{py:attribute} types
+:canonical: panelini.panels.wunderbaum.wunderbaum.Wunderbaum.types
+:value: >
+   'Dict(...)'
+
+```{autodoc2-docstring} panelini.panels.wunderbaum.wunderbaum.Wunderbaum.types
+```
+
+````
+
+````{py:attribute} context_menu_items
+:canonical: panelini.panels.wunderbaum.wunderbaum.Wunderbaum.context_menu_items
+:value: >
+   'List(...)'
+
+```{autodoc2-docstring} panelini.panels.wunderbaum.wunderbaum.Wunderbaum.context_menu_items
+```
+
+````
+
+````{py:method} handle_tree_event(event_name: str, event_params: dict[str, typing.Any]) -> None
+:canonical: panelini.panels.wunderbaum.wunderbaum.Wunderbaum.handle_tree_event
+
+```{autodoc2-docstring} panelini.panels.wunderbaum.wunderbaum.Wunderbaum.handle_tree_event
+```
+
+````
+
+````{py:method} get_source() -> list[dict[str, typing.Any]]
+:canonical: panelini.panels.wunderbaum.wunderbaum.Wunderbaum.get_source
+
+```{autodoc2-docstring} panelini.panels.wunderbaum.wunderbaum.Wunderbaum.get_source
+```
+
+````
+
+````{py:method} set_source(source: list[dict[str, typing.Any]]) -> None
+:canonical: panelini.panels.wunderbaum.wunderbaum.Wunderbaum.set_source
+
+```{autodoc2-docstring} panelini.panels.wunderbaum.wunderbaum.Wunderbaum.set_source
+```
+
+````
+
+````{py:method} add_node(parent_key: typing.Optional[str], node: dict[str, typing.Any]) -> None
+:canonical: panelini.panels.wunderbaum.wunderbaum.Wunderbaum.add_node
+
+```{autodoc2-docstring} panelini.panels.wunderbaum.wunderbaum.Wunderbaum.add_node
+```
+
+````
+
+````{py:method} remove_node(key: str) -> None
+:canonical: panelini.panels.wunderbaum.wunderbaum.Wunderbaum.remove_node
+
+```{autodoc2-docstring} panelini.panels.wunderbaum.wunderbaum.Wunderbaum.remove_node
+```
+
+````
+
+````{py:method} move_node(key: str, target_key: str, mode: str = 'child') -> None
+:canonical: panelini.panels.wunderbaum.wunderbaum.Wunderbaum.move_node
+
+```{autodoc2-docstring} panelini.panels.wunderbaum.wunderbaum.Wunderbaum.move_node
+```
+
+````
+
+````{py:method} update_node(key: str, data: dict[str, typing.Any]) -> None
+:canonical: panelini.panels.wunderbaum.wunderbaum.Wunderbaum.update_node
+
+```{autodoc2-docstring} panelini.panels.wunderbaum.wunderbaum.Wunderbaum.update_node
+```
+
+````
+
+````{py:method} rename_node(key: str, title: str) -> None
+:canonical: panelini.panels.wunderbaum.wunderbaum.Wunderbaum.rename_node
+
+```{autodoc2-docstring} panelini.panels.wunderbaum.wunderbaum.Wunderbaum.rename_node
+```
+
+````
+
+````{py:method} clear() -> None
+:canonical: panelini.panels.wunderbaum.wunderbaum.Wunderbaum.clear
+
+```{autodoc2-docstring} panelini.panels.wunderbaum.wunderbaum.Wunderbaum.clear
+```
+
+````
+
+````{py:method} expand_node(key: str, expanded: bool = True) -> None
+:canonical: panelini.panels.wunderbaum.wunderbaum.Wunderbaum.expand_node
+
+```{autodoc2-docstring} panelini.panels.wunderbaum.wunderbaum.Wunderbaum.expand_node
+```
+
+````
+
+````{py:method} select_node(key: str, selected: bool = True) -> None
+:canonical: panelini.panels.wunderbaum.wunderbaum.Wunderbaum.select_node
+
+```{autodoc2-docstring} panelini.panels.wunderbaum.wunderbaum.Wunderbaum.select_node
+```
+
+````
+
+````{py:method} set_active_node(key: str) -> None
+:canonical: panelini.panels.wunderbaum.wunderbaum.Wunderbaum.set_active_node
+
+```{autodoc2-docstring} panelini.panels.wunderbaum.wunderbaum.Wunderbaum.set_active_node
+```
+
+````
+
+````{py:method} respond_lazy_load(key: str, children: list[dict[str, typing.Any]]) -> None
+:canonical: panelini.panels.wunderbaum.wunderbaum.Wunderbaum.respond_lazy_load
+
+```{autodoc2-docstring} panelini.panels.wunderbaum.wunderbaum.Wunderbaum.respond_lazy_load
+```
+
+````
+
+````{py:method} batch_update(actions: list[dict[str, typing.Any]]) -> None
+:canonical: panelini.panels.wunderbaum.wunderbaum.Wunderbaum.batch_update
+
+```{autodoc2-docstring} panelini.panels.wunderbaum.wunderbaum.Wunderbaum.batch_update
+```
+
+````
+
+````{py:method} execute_step(step: dict[str, typing.Any]) -> None
+:canonical: panelini.panels.wunderbaum.wunderbaum.Wunderbaum.execute_step
+
+```{autodoc2-docstring} panelini.panels.wunderbaum.wunderbaum.Wunderbaum.execute_step
+```
+
+````
+
+````{py:method} add_folder(parent_key: typing.Optional[str], name: str, key: typing.Optional[str] = None) -> None
+:canonical: panelini.panels.wunderbaum.wunderbaum.Wunderbaum.add_folder
+
+```{autodoc2-docstring} panelini.panels.wunderbaum.wunderbaum.Wunderbaum.add_folder
+```
+
+````
+
+````{py:method} add_file(parent_key: typing.Optional[str], name: str, data: typing.Optional[dict[str, typing.Any]] = None, key: typing.Optional[str] = None) -> None
+:canonical: panelini.panels.wunderbaum.wunderbaum.Wunderbaum.add_file
+
+```{autodoc2-docstring} panelini.panels.wunderbaum.wunderbaum.Wunderbaum.add_file
+```
+
+````
+
+`````

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -31,6 +31,12 @@ Host two independent chats in synced tabs with `jslink`.
 Render a JSON-Schema driven form inside a Panelini card.
 :::
 
+:::{grid-item-card} Pydantic-backed JSON editor
+:link: jsoneditor_pydantic
+:link-type: doc
+Drive a JSON editor from a Pydantic model — schema and initial value derived automatically.
+:::
+
 :::{grid-item-card} VisNetwork graph
 :link: visnetwork
 :link-type: doc

--- a/docs/examples/jsoneditor_pydantic.md
+++ b/docs/examples/jsoneditor_pydantic.md
@@ -1,0 +1,73 @@
+# Pydantic-backed JSON editor
+
+**Source:** [`examples/panels/jsoneditor/jsoneditor_pydantic.py`](https://github.com/opensemanticworld/panelini/blob/main/examples/panels/jsoneditor/jsoneditor_pydantic.py)
+**Test:** [`tests/panels/jsoneditor/examples/test_jsoneditor_pydantic.py`](https://github.com/opensemanticworld/panelini/blob/main/tests/panels/jsoneditor/examples/test_jsoneditor_pydantic.py)
+
+Demonstrates a `PydanticEditor` subclass of `JsonEditor` that derives its schema from a Pydantic model and accepts model instances as the initial value.
+
+## The code
+
+```python
+from panelini.panels.jsoneditor import JsonEditor
+from pydantic import BaseModel, Field
+from pydantic._internal._model_construction import ModelMetaclass
+
+
+def _apply_formats(schema, array_tabs, dict_categories):
+    """Recursively inject 'tabs' / 'categories' format hints into a JSON schema."""
+    ...
+
+
+class PydanticEditor(JsonEditor):
+    def __init__(
+        self,
+        pydantic_model: ModelMetaclass,
+        value=None,
+        format_array_tabs: bool = False,
+        format_dict_categories: bool = False,
+        **params,
+    ):
+        json_schema = pydantic_model.model_json_schema()
+        if format_array_tabs or format_dict_categories:
+            json_schema = _apply_formats(json_schema, format_array_tabs, format_dict_categories)
+        params.setdefault("options", {})["schema"] = json_schema
+        super().__init__(**params)
+        if isinstance(value, BaseModel):
+            value = value.model_dump()
+        self.value = value
+```
+
+Key points:
+
+- **Schema derivation** — `model_json_schema()` converts the Pydantic model (including nested models and `$defs`) into the JSON Schema consumed by `json-editor`.
+- **Pydantic instance as value** — if `value` is a `BaseModel`, it is converted with `model_dump()` before being assigned to the `value` param, so callers never need to serialize manually.
+- **Initial value preserved on serve** — `value` is passed as `startval` to the JavaScript editor at mount time, preventing the first `change` event from resetting the form to schema defaults.
+- **`format_array_tabs`** — adds `"format": "tabs"` to every `"type": "array"` node in the schema, rendering list items as tabs.
+- **`format_dict_categories`** — adds `"format": "categories"` to every `"type": "object"` node, rendering object properties as category panels.
+
+## Data flow
+
+```{mermaid}
+graph LR
+    model([Pydantic model]) -- "model_json_schema()" --> schema([JSON Schema])
+    schema --> je[PydanticEditor]
+    instance([Pydantic instance]) -- "model_dump()" --> val([dict value])
+    val -- "startval" --> je
+    je -- "value sync" --> py[Python]
+    py -- "set_value" --> je
+```
+
+## How the test exercises it
+
+The Playwright test:
+
+1. Defines the same Pydantic models as the example (`A`, `ASub`) locally so the example file stays self-contained.
+2. Creates a fresh `PydanticEditor` via a pytest fixture.
+3. Serves it on a random port and navigates a headless browser to the URL.
+4. Asserts that `my_editor.value` still equals `a.model_dump()` after JS initialisation (regression test for the initial-value reset bug).
+5. Fills the `x` field with `42`, blurs the input, and asserts `my_editor.value["x"] == 42` (round-trip test).
+
+## See also
+
+- {doc}`../panels/jsoneditor` — full `JsonEditor` guide including initial value and Pydantic integration sections
+- [json-editor format options](https://github.com/json-editor/json-editor#format)

--- a/docs/index.md
+++ b/docs/index.md
@@ -143,6 +143,7 @@ examples/ai_chat_min
 examples/ai_chat_custom_tool
 examples/ai_chat_multi_tab
 examples/jsoneditor
+examples/jsoneditor_pydantic
 examples/visnetwork
 ```
 

--- a/docs/panels/jsoneditor.md
+++ b/docs/panels/jsoneditor.md
@@ -73,6 +73,40 @@ editor = JsonEditor(
 )
 ```
 
+## Initial Value
+
+Pass `value` as a keyword argument to pre-populate the form. The value is preserved when the panel is served — the JavaScript editor is initialised with it as `startval`, so the first `change` event reflects the supplied data instead of schema defaults.
+
+```python
+editor = JsonEditor(
+    options={"schema": schema},
+    value={"name": "Alice", "age": 30, "email": "alice@example.com"},
+)
+```
+
+## Pydantic Integration
+
+`JsonEditor` can be subclassed to accept Pydantic model instances directly. The example in [`examples/panels/jsoneditor/jsoneditor_pydantic.py`](https://github.com/opensemanticworld/panelini/blob/main/examples/panels/jsoneditor/jsoneditor_pydantic.py) shows a `PydanticEditor` that:
+
+- derives the JSON Schema automatically from the Pydantic model via `model_json_schema()`
+- accepts either a Pydantic instance or a plain dict as `value`
+- optionally renders arrays as tabs (`format_array_tabs=True`) and objects as category panels (`format_dict_categories=True`)
+
+```python
+from pydantic import BaseModel, Field
+from panelini.panels.jsoneditor import JsonEditor
+
+class MyModel(BaseModel):
+    name: str = Field(..., description="Full name")
+    score: int = Field(0, description="Score")
+
+instance = MyModel(name="Alice", score=42)
+
+editor = PydanticEditor(MyModel, value=instance, format_array_tabs=True)
+```
+
+See {doc}`../examples/jsoneditor_pydantic` for the full walkthrough.
+
 ## API Reference
 
 See the full API documentation: {py:class}`panelini.panels.jsoneditor.jsoneditor.JsonEditor`

--- a/examples/panels/jsoneditor/jsoneditor_pydantic.py
+++ b/examples/panels/jsoneditor/jsoneditor_pydantic.py
@@ -1,0 +1,76 @@
+import panel as pn
+from pydantic import BaseModel, Field
+from pydantic._internal._model_construction import ModelMetaclass
+
+from panelini.panels.jsoneditor import JsonEditor
+
+
+def _apply_formats(schema: dict, array_tabs: bool, dict_categories: bool) -> dict:
+    if not isinstance(schema, dict):
+        return schema
+    schema = dict(schema)
+    node_type = schema.get("type")
+    if array_tabs and node_type == "array" and "format" not in schema:
+        schema["format"] = "tabs"
+    if dict_categories and node_type == "object" and "format" not in schema:
+        schema["format"] = "categories"
+    for key in ("properties", "$defs"):
+        if key in schema:
+            schema[key] = {k: _apply_formats(v, array_tabs, dict_categories) for k, v in schema[key].items()}
+    for key in ("items", "additionalProperties", "not"):
+        if key in schema:
+            schema[key] = _apply_formats(schema[key], array_tabs, dict_categories)
+    for key in ("anyOf", "allOf", "oneOf"):
+        if key in schema:
+            schema[key] = [_apply_formats(s, array_tabs, dict_categories) for s in schema[key]]
+    return schema
+
+
+class PydanticEditor(JsonEditor):
+    def __init__(
+        self,
+        pydantic_model: ModelMetaclass,
+        value=None,
+        format_array_tabs: bool = False,
+        format_dict_categories: bool = False,
+        **params,
+    ):
+        self.pydantic_model = pydantic_model
+        self.schema = self.pydantic_model.schema()
+
+        options = params.get("options", {})
+
+        if self.pydantic_model is not None:
+            json_schema = self.pydantic_model.model_json_schema()
+            if format_array_tabs or format_dict_categories:
+                json_schema = _apply_formats(json_schema, format_array_tabs, format_dict_categories)
+            options["schema"] = json_schema
+        else:
+            options["schema"] = {}
+
+        params["options"] = options
+        super().__init__(**params)
+        if isinstance(value, BaseModel):
+            value = value.model_dump()
+        self.value = value
+
+
+if __name__ == "__main__":
+    import time
+    from typing import Optional
+
+    class ASub(BaseModel):
+        a: int = Field(..., description="prop a of sub property ASub")
+        b: int = Field(..., description="prop b of sub property ASub")
+
+    class A(BaseModel):
+        x: int = Field(..., description="x function_config")
+        y: int = Field(..., description="y function_config")
+        z: Optional[int] = Field(None, description="z function_config")
+        sub: list[ASub] = Field([], description="sub property of A, which is of type ASub")
+
+    a = A(x=1, y=2, z=3, sub=[ASub(a=1, b=2), ASub(a=4, b=3)])
+
+    my_editor = PydanticEditor(A, value=a, format_array_tabs=True, format_dict_categories=False)
+    time.sleep(1)
+    pn.serve(my_editor, threaded=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "panelini"
-version = "0.9.1"
+version = "0.9.2"
 description = "Panelini is a user-friendly Python package designed to provide an out-of-the-box panel with a beautiful and responsive layout. It simplifies the creation of interactive dashboards by handling dynamic content seamlessly using Python Panel components. Whether you're building complex data visualizations or simple interactive interfaces, panelini offers an easy-to-use solution that enhances productivity and aesthetics."
 authors = [{ name = "Andreas Räder", email = "andreas.raeder@isc.fraunhofer.de" }]
 readme = "README.md"

--- a/src/panelini/panels/jsoneditor/vue/dist/jsoneditor_vue.mjs
+++ b/src/panelini/panels/jsoneditor/vue/dist/jsoneditor_vue.mjs
@@ -15622,21 +15622,23 @@ function Om({ model: l, el: u }) {
     }
     //   startval: this.data
   };
-  const C = bm(xm, {
+  const _ = l.get("value");
+  _ != null && w.startval === void 0 && (w = { ...w, startval: _ });
+  const d = bm(xm, {
     options: w,
-    onChange: (d) => {
-      console.debug("CHANGE", d), d instanceof Event || (l.set("value", d), l.save_changes());
+    onChange: (g) => {
+      console.debug("CHANGE", g), g instanceof Event || (l.set("value", g), l.save_changes());
     },
-    onReady: (d) => {
-      console.debug("JSONEditor is ready"), l.set("ready", d), l.save_changes();
+    onReady: (g) => {
+      console.debug("JSONEditor is ready"), l.set("ready", g), l.save_changes();
     }
   }).mount(u);
   l.on("change:value", () => {
-    C.setValue(l.get("value"));
+    d.setValue(l.get("value"));
   }), l.on("change:options", () => {
-    C.setOptions(l.get("options"));
+    d.setOptions(l.get("options"));
   }), l.on("change:schema", () => {
-    C.setSchema(l.get("schema"));
+    d.setSchema(l.get("schema"));
   });
 }
 export {

--- a/src/panelini/panels/jsoneditor/vue/src/jsoneditor_component.js
+++ b/src/panelini/panels/jsoneditor/vue/src/jsoneditor_component.js
@@ -20,6 +20,10 @@ export function render({ model, el }) {
       "properties": {"test": {"type": "string"}}},
     //   startval: this.data
   }
+  const initialValue = model.get("value");
+  if (initialValue !== null && initialValue !== undefined && options.startval === undefined) {
+    options = { ...options, startval: initialValue };
+  }
   const app = createApp(JsonEditorComponent, {
     options: options,
     onChange: (value) => {

--- a/tests/panels/jsoneditor/examples/test_jsoneditor_pydantic.py
+++ b/tests/panels/jsoneditor/examples/test_jsoneditor_pydantic.py
@@ -1,0 +1,68 @@
+"""Playwright test: PydanticEditor renders with the correct initial value."""
+
+import time
+from typing import Optional
+
+import panel as pn
+import pytest
+from playwright.sync_api import Page
+from pydantic import BaseModel, Field
+
+from examples.panels.jsoneditor.jsoneditor_pydantic import PydanticEditor
+
+
+class ASub(BaseModel):
+    a: int = Field(..., description="prop a of sub property ASub")
+    b: int = Field(..., description="prop b of sub property ASub")
+
+
+class A(BaseModel):
+    x: int = Field(..., description="x function_config")
+    y: int = Field(..., description="y function_config")
+    z: Optional[int] = Field(None, description="z function_config")
+    sub: list[ASub] = Field([], description="sub property of A, which is of type ASub")
+
+
+@pytest.fixture
+def editor():
+    a = A(x=1, y=2, z=3, sub=[ASub(a=1, b=2), ASub(a=4, b=3)])
+    return PydanticEditor(A, value=a, format_array_tabs=True, format_dict_categories=False), a
+
+
+def test_initial_value_displayed(page: Page, port, editor):
+    """Editor renders with the Pydantic instance value, not schema defaults."""
+    my_editor, a = editor
+    server = pn.serve(my_editor, port=port, threaded=True, show=False)
+    time.sleep(0.2)
+
+    page.goto(f"http://localhost:{port}")
+    time.sleep(3)  # wait for JSONEditor to initialise
+
+    # Python-side value must still match the Pydantic instance after JS init
+    assert my_editor.value == a.model_dump(), (
+        f"Value was reset on serve: expected {a.model_dump()!r}, got {my_editor.value!r}"
+    )
+
+    # Fields rendered with the correct initial values
+    assert page.locator("#root\\[x\\]").input_value() == str(a.x)
+    assert page.locator("#root\\[y\\]").input_value() == str(a.y)
+
+    server.stop()
+
+
+def test_value_change_propagates_to_python(page: Page, port, editor):
+    """Editing a field in the browser updates the Python-side value."""
+    my_editor, _ = editor
+    server = pn.serve(my_editor, port=port, threaded=True, show=False)
+    time.sleep(0.2)
+
+    page.goto(f"http://localhost:{port}")
+    time.sleep(3)
+
+    page.locator("#root\\[x\\]").fill("42")
+    page.locator("[for=root\\[x\\]]").click()  # blur to trigger change event
+    time.sleep(0.5)
+
+    assert my_editor.value["x"] == 42
+
+    server.stop()

--- a/tests/panels/jsoneditor/test_jsoneditor_ui.py
+++ b/tests/panels/jsoneditor/test_jsoneditor_ui.py
@@ -1,0 +1,41 @@
+"""UI tests for JsonEditor — require a headless browser via Playwright.
+
+Importing from playwright auto-marks every test in this module with the
+``ui`` marker (see tests/conftest.py), so these tests are excluded from
+``make test`` and only run via ``make test-ui`` or ``make test-full``.
+"""
+
+import time
+
+import panel as pn
+import pytest
+from playwright.sync_api import Page
+
+from panelini.panels.jsoneditor import JsonEditor
+
+
+@pytest.mark.ui
+def test_initial_value_not_reset_on_serve(page: Page, port):
+    """The Python-side value must survive the JS initialisation change event.
+
+    Without the startval fix the JSONEditor boots with schema defaults, fires a
+    'change' event, and save_changes() overwrites the Python value with those
+    defaults. This test connects a real browser so the JS actually executes.
+    """
+    initial_value = {"testxy": "hello"}
+    editor = JsonEditor(value=initial_value)
+
+    server = pn.serve(editor, port=port, threaded=True, show=False)
+    page.goto(f"http://localhost:{port}")
+
+    # Poll until the JS 'ready' event has propagated back to Python.
+    # 'ready' fires after the initial 'change' event, so once editor.ready
+    # is True the value has already been set (or incorrectly reset).
+    deadline = time.time() + 10
+    while not editor.ready and time.time() < deadline:
+        time.sleep(0.1)
+
+    assert editor.ready, "JSONEditor did not become ready within 10 s"
+    assert editor.value == initial_value, f"Value was reset on serve: expected {initial_value!r}, got {editor.value!r}"
+
+    server.stop()

--- a/uv.lock
+++ b/uv.lock
@@ -2583,7 +2583,7 @@ wheels = [
 
 [[package]]
 name = "panelini"
-version = "0.9.1"
+version = "0.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "panel" },


### PR DESCRIPTION
Pass model value as startval when initialising the JS JSONEditor so the first change event does not overwrite the Python-side value with schema defaults. Adds PydanticEditor example with tabs/categories format support and Playwright tests covering the fix.

Fix #33