### PR TITLE
feat: add TerminalMirror panel

### DIFF
--- a/docs/apidocs/panelini/panelini.md
+++ b/docs/apidocs/panelini/panelini.md
@@ -13,8 +13,8 @@
 :titlesonly:
 :maxdepth: 3
 
-panelini.components
 panelini.panels
+panelini.components
 ```
 
 ## Submodules

--- a/docs/apidocs/panelini/panelini.panels.ai.plot.tools.md
+++ b/docs/apidocs/panelini/panelini.panels.ai.plot.tools.md
@@ -13,7 +13,7 @@
 :titlesonly:
 :maxdepth: 1
 
-panelini.panels.ai.plot.tools.osw_plot_tools
-panelini.panels.ai.plot.tools.osw_tools
 panelini.panels.ai.plot.tools.plot_tools
+panelini.panels.ai.plot.tools.osw_tools
+panelini.panels.ai.plot.tools.osw_plot_tools
 ```

--- a/docs/apidocs/panelini/panelini.panels.ai.plot.utils.md
+++ b/docs/apidocs/panelini/panelini.panels.ai.plot.utils.md
@@ -13,6 +13,6 @@
 :titlesonly:
 :maxdepth: 1
 
-panelini.panels.ai.plot.utils.osw_env
 panelini.panels.ai.plot.utils.sandbox
+panelini.panels.ai.plot.utils.osw_env
 ```

--- a/docs/apidocs/panelini/panelini.panels.md
+++ b/docs/apidocs/panelini/panelini.panels.md
@@ -14,6 +14,7 @@
 :maxdepth: 3
 
 panelini.panels.ai
+panelini.panels.terminalmirror
 panelini.panels.jsoneditor
 panelini.panels.visnetwork
 panelini.panels.wunderbaum

--- a/docs/apidocs/panelini/panelini.panels.terminalmirror.md
+++ b/docs/apidocs/panelini/panelini.panels.terminalmirror.md
@@ -1,0 +1,17 @@
+# {py:mod}`panelini.panels.terminalmirror`
+
+```{py:module} panelini.panels.terminalmirror
+```
+
+```{autodoc2-docstring} panelini.panels.terminalmirror
+:allowtitles:
+```
+
+## Submodules
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
+panelini.panels.terminalmirror.terminalmirror
+```

--- a/docs/apidocs/panelini/panelini.panels.terminalmirror.terminalmirror.md
+++ b/docs/apidocs/panelini/panelini.panels.terminalmirror.terminalmirror.md
@@ -1,0 +1,108 @@
+# {py:mod}`panelini.panels.terminalmirror.terminalmirror`
+
+```{py:module} panelini.panels.terminalmirror.terminalmirror
+```
+
+```{autodoc2-docstring} panelini.panels.terminalmirror.terminalmirror
+:allowtitles:
+```
+
+## Module Contents
+
+### Classes
+
+````{list-table}
+:class: autosummary longtable
+:align: left
+
+* - {py:obj}`TerminalMirror <panelini.panels.terminalmirror.terminalmirror.TerminalMirror>`
+  - ```{autodoc2-docstring} panelini.panels.terminalmirror.terminalmirror.TerminalMirror
+    :summary:
+    ```
+````
+
+### API
+
+`````{py:class} TerminalMirror(mirror: bool = True, **params: typing.Any)
+:canonical: panelini.panels.terminalmirror.terminalmirror.TerminalMirror
+
+Bases: {py:obj}`panel.viewable.Viewer`
+
+```{autodoc2-docstring} panelini.panels.terminalmirror.terminalmirror.TerminalMirror
+```
+
+```{rubric} Initialization
+```
+
+```{autodoc2-docstring} panelini.panels.terminalmirror.terminalmirror.TerminalMirror.__init__
+```
+
+````{py:attribute} sizing_mode
+:canonical: panelini.panels.terminalmirror.terminalmirror.TerminalMirror.sizing_mode
+:value: >
+   'String(...)'
+
+```{autodoc2-docstring} panelini.panels.terminalmirror.terminalmirror.TerminalMirror.sizing_mode
+```
+
+````
+
+````{py:attribute} options
+:canonical: panelini.panels.terminalmirror.terminalmirror.TerminalMirror.options
+:value: >
+   'Dict(...)'
+
+```{autodoc2-docstring} panelini.panels.terminalmirror.terminalmirror.TerminalMirror.options
+```
+
+````
+
+````{py:method} start() -> None
+:canonical: panelini.panels.terminalmirror.terminalmirror.TerminalMirror.start
+
+```{autodoc2-docstring} panelini.panels.terminalmirror.terminalmirror.TerminalMirror.start
+```
+
+````
+
+````{py:method} stop() -> None
+:canonical: panelini.panels.terminalmirror.terminalmirror.TerminalMirror.stop
+
+```{autodoc2-docstring} panelini.panels.terminalmirror.terminalmirror.TerminalMirror.stop
+```
+
+````
+
+````{py:method} write(data: str) -> int
+:canonical: panelini.panels.terminalmirror.terminalmirror.TerminalMirror.write
+
+```{autodoc2-docstring} panelini.panels.terminalmirror.terminalmirror.TerminalMirror.write
+```
+
+````
+
+````{py:method} flush() -> None
+:canonical: panelini.panels.terminalmirror.terminalmirror.TerminalMirror.flush
+
+```{autodoc2-docstring} panelini.panels.terminalmirror.terminalmirror.TerminalMirror.flush
+```
+
+````
+
+````{py:method} redraw() -> None
+:canonical: panelini.panels.terminalmirror.terminalmirror.TerminalMirror.redraw
+
+```{autodoc2-docstring} panelini.panels.terminalmirror.terminalmirror.TerminalMirror.redraw
+```
+
+````
+
+````{py:method} bind_collapse(card: panel.Card) -> None
+:canonical: panelini.panels.terminalmirror.terminalmirror.TerminalMirror.bind_collapse
+
+```{autodoc2-docstring} panelini.panels.terminalmirror.terminalmirror.TerminalMirror.bind_collapse
+```
+
+````
+
+`````

--- a/docs/apidocs/panelini/panelini.panels.visnetwork.md
+++ b/docs/apidocs/panelini/panelini.panels.visnetwork.md
@@ -14,6 +14,6 @@
 :maxdepth: 1
 
 panelini.panels.visnetwork.graph_detail_tool
-panelini.panels.visnetwork.utils
 panelini.panels.visnetwork.visnetwork
+panelini.panels.visnetwork.utils
 ```

--- a/docs/panels/index.md
+++ b/docs/panels/index.md
@@ -29,6 +29,12 @@ High-level workspace that composes VisNetwork + JsonEditor with a detail pane.
 LangChain-powered chat panel with multi-provider support, tools, and live preview.
 :::
 
+:::{grid-item-card} TerminalMirror
+:link: terminalmirror
+:link-type: doc
+Mirror sys.stdout into an on-screen terminal widget with automatic collapse/expand buffer replay.
+:::
+
 ::::
 
 ```{mermaid}
@@ -38,6 +44,7 @@ graph LR
         vn(["VisNetwork"])
         gdt(["GraphDetailTool"])
         ai(["AiChat"])
+        tm(["TerminalMirror"])
     end
 
     panelini(["Panelini App"])
@@ -51,7 +58,7 @@ graph LR
     classDef panelNode fill:#0d7377,stroke:#095c5f,color:#ffffff
     classDef targetNode fill:#1e293b,stroke:#334155,color:#f8fafc
 
-    class je,vn,gdt,ai panelNode
+    class je,vn,gdt,ai,tm panelNode
     class panelini,standalone,other targetNode
 ```
 
@@ -76,6 +83,9 @@ graph LR
 * - {doc}`AiChat <ai>`
   - LLM-powered chat interface with multi-provider support, tool execution, and live preview
   - [LangChain](https://python.langchain.com/) + Panel ChatInterface
+* - {doc}`TerminalMirror <terminalmirror>`
+  - Mirror sys.stdout into an on-screen terminal widget; auto-wires collapse/expand buffer replay
+  - Panel Terminal (xterm.js)
 ```
 
 ## Design Principles
@@ -95,4 +105,5 @@ All panels follow these design principles:
 jsoneditor
 visnetwork
 ai
+terminalmirror
 ```

--- a/docs/panels/terminalmirror.md
+++ b/docs/panels/terminalmirror.md
@@ -1,0 +1,75 @@
+# TerminalMirror
+
+`TerminalMirror` mirrors `sys.stdout` into an on-screen `pn.widgets.Terminal` widget while forwarding every write to the original stream, so the real console still receives output.
+
+## Usage
+
+```python
+from panelini.panels.terminalmirror import TerminalMirror
+
+terminal = TerminalMirror()          # starts mirroring immediately
+print("Hello!")                      # appears in widget and in the console
+terminal.stop()
+```
+
+Pass `mirror=False` to defer redirection — useful when the component is
+created at import time and you only want to start capturing on demand:
+
+```python
+terminal = TerminalMirror(mirror=False)
+
+def on_click(event):
+    terminal.start()
+    print("captured from here on")
+```
+
+## Context manager
+
+```python
+with TerminalMirror() as terminal:
+    print("captured")               # appears in widget and console
+# sys.stdout is restored here
+```
+
+## Collapse / expand in a Card
+
+When the terminal is placed inside a `pn.Card`, the xterm.js frontend buffer
+is destroyed on collapse. `TerminalMirror` **automatically** wires the
+collapse/expand replay when any `pn.Card` is constructed that contains it —
+no extra call needed:
+
+```python
+import panel as pn
+from panelini.panels.terminalmirror import TerminalMirror
+
+terminal = TerminalMirror(mirror=False)
+
+card = pn.Card(terminal, title="Output")   # collapse watcher registered automatically
+```
+
+The same applies when the terminal is nested inside a custom `pn.viewable.Viewer`:
+
+```python
+class MyApp(pn.viewable.Viewer):
+    def __init__(self):
+        super().__init__()
+        self.terminal = TerminalMirror(mirror=False)
+        self._view = pn.Column(self.terminal)
+
+    def __panel__(self):
+        return self._view
+
+app = MyApp()
+card = pn.Card(app, title="Output")   # TerminalMirror inside MyApp is found and wired
+```
+
+To wire a card that was constructed *before* the terminal existed, call
+`bind_collapse` manually (it is idempotent — safe to call more than once):
+
+```python
+terminal.bind_collapse(card)
+```
+
+## API Reference
+
+See the full API documentation: {py:class}`panelini.panels.terminalmirror.terminalmirror.TerminalMirror`

--- a/examples/panels/jsoneditor/jsoneditor_pydantic.py
+++ b/examples/panels/jsoneditor/jsoneditor_pydantic.py
@@ -36,7 +36,7 @@ class PydanticEditor(JsonEditor):
         **params,
     ):
         self.pydantic_model = pydantic_model
-        self.schema = self.pydantic_model.schema()
+        self.schema = self.pydantic_model.model_json_schema()
 
         options = params.get("options", {})
 

--- a/examples/panels/terminalmirror/terminalmirror_panel_min.py
+++ b/examples/panels/terminalmirror/terminalmirror_panel_min.py
@@ -1,0 +1,49 @@
+"""Minimal example demonstrating the TerminalMirror panel.
+
+Click the button to print to ``stdout``: the text appears both in the on-screen
+terminal widget and on the real console.
+"""
+
+import panel as pn
+
+from panelini.panels.terminalmirror import TerminalMirror
+
+
+class App(pn.viewable.Viewer):
+    def __init__(self, **params):
+        super().__init__(**params)
+
+        # mirror=False keeps module import side-effect free; mirroring is started
+        # lazily on the first button click (start() is idempotent).
+        self.terminal = TerminalMirror(mirror=False)
+
+        self._count = 0
+        self.print_btn = pn.widgets.Button(css_classes=["print_btn"], name="Print to terminal", button_type="primary")
+        pn.bind(self.on_print, self.print_btn, watch=True)
+
+        self._view = pn.Column(
+            self.print_btn,
+            self.terminal,
+            sizing_mode="stretch_both",
+        )
+
+    def on_print(self, event):
+        self.terminal.start()
+        self._count += 1
+        print(f"Hello from TerminalMirror! (click #{self._count})")
+
+    def __panel__(self):
+        return self._view
+
+
+# Module-level instances so tests can import and serve the app.
+app = App()
+terminal = app.terminal
+
+if pn.state.served:
+    pn.extension(sizing_mode="stretch_width")
+
+    app.servable()
+
+if __name__ == "__main__":
+    pn.serve(app)

--- a/examples/panels/terminalmirror/terminalmirror_panelini_min.py
+++ b/examples/panels/terminalmirror/terminalmirror_panelini_min.py
@@ -1,0 +1,63 @@
+"""Simple TerminalMirror example wrapped in Panelini."""
+
+import panel as pn
+
+from panelini import Panelini
+from panelini.panels.terminalmirror import TerminalMirror
+
+
+class TerminalMirrorDemo(pn.viewable.Viewer):
+    def __init__(self, **params):
+        super().__init__(**params)
+
+        # mirror=False keeps module import side-effect free; mirroring is started
+        # lazily on the first button click (start() is idempotent).
+        # The terminal stretches to fill the content area by default.
+        self.terminal = TerminalMirror(mirror=False)
+
+        self._count = 0
+        self.print_btn = pn.widgets.Button(css_classes=["print_btn"], name="Print to terminal", button_type="primary")
+        pn.bind(self.on_print, self.print_btn, watch=True)
+
+        self._view = pn.Column(
+            self.print_btn,
+            self.terminal,
+            sizing_mode="stretch_both",
+        )
+
+    def on_print(self, event):
+        self.terminal.start()
+        self._count += 1
+        print(f"Hello from TerminalMirror! (click #{self._count})")
+
+    def __panel__(self):
+        return self._view
+
+
+# Module-level instances so tests can import and serve the app.
+terminalmirror_panel = TerminalMirrorDemo()
+
+
+card = pn.Card(
+    title="Terminal Mirror",
+    objects=[terminalmirror_panel],
+    sizing_mode="stretch_both",
+)
+
+# Create an instance of Panelini
+app = Panelini(
+    title="🖥️ Terminal Mirror Demo",
+    sidebar_enabled=False,
+)
+
+# Set the main content with the demo component
+# Row wrapping is for collapse bahaviour of card content
+app.main_set(objects=[pn.Row(card)])
+
+# Servable for debugging using command
+# panel serve terminalmirror_panelini_min.py --dev
+app.servable()
+
+if __name__ == "__main__":
+    # Serve app as you would in panel
+    pn.io.server.serve(app, port=5010)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "panelini"
-version = "0.9.2"
+version = "0.9.3"
 description = "Panelini is a user-friendly Python package designed to provide an out-of-the-box panel with a beautiful and responsive layout. It simplifies the creation of interactive dashboards by handling dynamic content seamlessly using Python Panel components. Whether you're building complex data visualizations or simple interactive interfaces, panelini offers an easy-to-use solution that enhances productivity and aesthetics."
 authors = [{ name = "Andreas Räder", email = "andreas.raeder@isc.fraunhofer.de" }]
 readme = "README.md"

--- a/src/panelini/panels/terminalmirror/__init__.py
+++ b/src/panelini/panels/terminalmirror/__init__.py
@@ -1,0 +1,5 @@
+"""TerminalMirror panel: mirror stdout into an on-screen terminal widget."""
+
+from .terminalmirror import TerminalMirror
+
+__all__ = ["TerminalMirror"]

--- a/src/panelini/panels/terminalmirror/terminalmirror.py
+++ b/src/panelini/panels/terminalmirror/terminalmirror.py
@@ -1,0 +1,226 @@
+"""Entrypoint of terminalmirror panel."""
+
+import contextlib
+import sys
+from types import TracebackType
+from typing import Any, Optional, TextIO
+
+import panel as pn
+import param  # type: ignore[import-untyped]
+
+pn.extension()
+
+
+class TerminalMirror(pn.viewable.Viewer):
+    """Mirror ``sys.stdout`` into an on-screen ``pn.widgets.Terminal``.
+
+    While active, everything written to ``sys.stdout`` is shown in the embedded
+    terminal widget *and* forwarded to the original stream, so the real console
+    still receives the output (inspired by the classic "tee stdout to a log"
+    recipe, https://stackoverflow.com/questions/616645).
+
+    Redirection is opt-in: it starts automatically on construction unless
+    ``mirror=False`` is passed, and can be controlled explicitly via
+    :meth:`start`/:meth:`stop` or by using the instance as a context manager::
+
+        with TerminalMirror() as term:
+            print("captured")  # appears in the widget and on the console
+
+    ``stop`` only restores ``sys.stdout`` when this instance is still the active
+    stream, so it never clobbers an unrelated redirect installed afterwards.
+    """
+
+    sizing_mode = param.String(default="stretch_both", doc="Panel sizing mode of the terminal widget.")
+    options = param.Dict(
+        default={"cursorBlink": True},
+        doc="Options forwarded to the underlying xterm.js terminal.",
+    )
+
+    def __init__(self, mirror: bool = True, **params: Any) -> None:
+        """Initialize the TerminalMirror.
+
+        When this instance is placed inside a ``pn.Card`` (directly or via a
+        nested ``pn.viewable.Viewer``), collapse/expand buffer-replay is wired
+        automatically — no explicit :meth:`bind_collapse` call required.
+
+        Args:
+            mirror: If True (default), immediately redirect ``sys.stdout`` into
+                the terminal widget. If False, the widget is created but
+                redirection must be started explicitly via :meth:`start`.
+            **params: Additional parameters passed to ``pn.viewable.Viewer``.
+        """
+        super().__init__(**params)
+
+        self._terminal = pn.widgets.Terminal(
+            options=self.options,
+            sizing_mode=self.sizing_mode,
+        )
+        self._original_stdout: Optional[TextIO] = None
+        self._bound_cards: set[int] = set()
+
+        if mirror:
+            self.start()
+
+    def start(self) -> None:
+        """Redirect ``sys.stdout`` into the terminal widget.
+
+        Idempotent: calling it again while already active is a no-op.
+        """
+        if self._original_stdout is not None:
+            return
+        self._original_stdout = sys.stdout
+        sys.stdout = self
+
+    def stop(self) -> None:
+        """Restore the original ``sys.stdout``.
+
+        Idempotent and safe: only restores when this instance is still the
+        active stream, so a redirect installed after :meth:`start` is left
+        untouched.
+        """
+        if self._original_stdout is None:
+            return
+        if sys.stdout is self:
+            sys.stdout = self._original_stdout
+        self._original_stdout = None
+
+    def write(self, data: str) -> int:
+        """Write ``data`` to the terminal widget and the original stream.
+
+        Args:
+            data: The text to write.
+
+        Returns:
+            The number of characters written (file-like contract).
+        """
+        self._terminal.write(data)
+        if self._original_stdout is not None:
+            self._original_stdout.write(data)
+        return len(data)
+
+    def flush(self) -> None:
+        """Flush the terminal widget and the original stream."""
+        self._terminal.flush()
+        if self._original_stdout is not None:
+            self._original_stdout.flush()
+
+    def redraw(self) -> None:
+        """Re-render the full buffer into the terminal widget.
+
+        Panel's ``Terminal`` only streams the latest chunk to the browser; the
+        full scrollback lives in the frontend xterm.js buffer, which is
+        destroyed whenever the widget is unmounted (e.g. when a containing
+        ``Card`` is collapsed). Calling this on remount clears the widget and
+        replays the accumulated output so nothing is lost.
+        """
+        output = self._terminal.output
+        self._terminal.clear()
+        if output:
+            self._terminal.write(output)
+
+    def _bind_to_card(self, card: pn.Card) -> None:
+        """Bind to *card* (delegates to :meth:`bind_collapse`, which deduplicates)."""
+        self.bind_collapse(card)
+
+    def bind_collapse(self, card: pn.Card) -> None:
+        """Wire a collapsible ``Card`` so the buffer survives collapse/expand.
+
+        Collapsing a ``Card`` unmounts the terminal and destroys its frontend
+        scrollback, and Panel provides no Python-side remount hook (the model is
+        reused, so ``_get_model`` is not called again). This watches the card's
+        ``collapsed`` state and :meth:`redraw`\\ s the accumulated output each
+        time it is expanded.
+
+        Idempotent: calling it again with the same card is a no-op.
+
+        This is called automatically when a ``pn.Card`` is created that contains
+        this ``TerminalMirror`` (directly or nested inside a
+        ``pn.viewable.Viewer``). Call manually only when the terminal is added
+        to a card *after* the card is constructed.
+
+        Args:
+            card: The ``pn.Card`` (or any object with a ``collapsed`` param)
+                that contains this terminal.
+        """
+        if id(card) in self._bound_cards:
+            return
+        self._bound_cards.add(id(card))
+
+        def _redraw_on_expand(event: Any) -> None:
+            if event.new is False:  # collapsed -> expanded
+                self.redraw()
+
+        card.param.watch(_redraw_on_expand, "collapsed")
+
+    def __enter__(self) -> "TerminalMirror":
+        """Start redirection on entering the context."""
+        self.start()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        """Stop redirection on leaving the context."""
+        self.stop()
+
+    def __del__(self) -> None:
+        """Best-effort restore of ``sys.stdout`` on garbage collection."""
+        with contextlib.suppress(Exception):
+            self.stop()
+
+    def __panel__(self) -> pn.widgets.Terminal:
+        """Return the underlying terminal widget for rendering."""
+        return self._terminal
+
+
+# ---------------------------------------------------------------------------
+# Auto-wire collapse behaviour when a pn.Card containing a TerminalMirror is
+# created.  The patch fires once per Card construction, walks the object tree,
+# and calls _bind_to_card on every TerminalMirror it finds.
+# ---------------------------------------------------------------------------
+
+
+def _find_and_bind_terminal_mirrors(obj: Any, card: pn.Card, visited: set) -> None:
+    """Find ``TerminalMirror`` instances in *obj* and bind them to *card*.
+
+    Panel unwraps ``Viewer`` subclasses when storing them in layout ``objects``,
+    so walking ``card.objects`` never surfaces a ``TerminalMirror``.  Instead
+    this function receives the *original* arguments passed to the Card (before
+    Panel processes them) and searches ``Viewer`` instance attributes directly.
+    """
+    if id(obj) in visited:
+        return
+    visited.add(id(obj))
+
+    if isinstance(obj, TerminalMirror):
+        obj._bind_to_card(card)
+        return
+
+    if isinstance(obj, pn.viewable.Viewer):
+        with contextlib.suppress(Exception):
+            for attr_val in vars(obj).values():
+                if isinstance(attr_val, (TerminalMirror, pn.viewable.Viewer)):
+                    _find_and_bind_terminal_mirrors(attr_val, card, visited)
+
+
+def _patch_pn_card_for_terminal_mirror() -> None:
+    if getattr(pn.Card, "_terminalmirror_collapse_patched", False):
+        return
+    _orig_init = pn.Card.__init__
+
+    def _patched_init(self: pn.Card, *args: Any, **kwargs: Any) -> None:
+        _orig_init(self, *args, **kwargs)
+        # Use the original args — card.objects already has Viewers unwrapped
+        original_objects = list(args) + list(kwargs.get("objects", []))
+        visited: set[int] = set()
+        for obj in original_objects:
+            _find_and_bind_terminal_mirrors(obj, self, visited)
+
+    pn.Card.__init__ = _patched_init  # type: ignore[method-assign]
+    pn.Card._terminalmirror_collapse_patched = True
+
+
+_patch_pn_card_for_terminal_mirror()

--- a/tests/panels/terminalmirror/conftest.py
+++ b/tests/panels/terminalmirror/conftest.py
@@ -1,0 +1,23 @@
+"""Shared configuration and fixtures for testing TerminalMirror panel."""
+
+import panel as pn
+import pytest
+
+PORT = [9000]
+
+
+@pytest.fixture
+def port():
+    PORT[0] += 1
+    return PORT[0]
+
+
+@pytest.fixture(autouse=True)
+def server_cleanup():
+    """
+    Clean up server state after each test.
+    """
+    try:
+        yield
+    finally:
+        pn.state.reset()

--- a/tests/panels/terminalmirror/examples/test_terminalmirror_panelini_min.py
+++ b/tests/panels/terminalmirror/examples/test_terminalmirror_panelini_min.py
@@ -1,0 +1,45 @@
+# pip install panel pytest pytest-playwright
+# playwright install
+# pytest test_terminalmirror_panelini_min.py --headed --slowmo 1000
+
+import time
+
+import panel as pn
+from playwright.sync_api import Page
+
+from examples.panels.terminalmirror.terminalmirror_panelini_min import app, terminalmirror_panel
+
+
+def test_component(page: Page, port):
+    url = f"http://localhost:{port}"
+
+    server = pn.serve(app, port=port, threaded=True, show=False)
+    time.sleep(0.2)
+
+    page.goto(url)
+    time.sleep(3)  # wait for page to load
+
+    # The terminal widget (xterm.js) is rendered within the Panelini app.
+    assert page.locator(".xterm").first.is_visible()
+
+    # Check that the Panelini Card title is present.
+    assert page.locator("text=Terminal Mirror").first.is_visible()
+
+    # Click the button: output should be mirrored into the terminal widget.
+    page.locator(".print_btn button").first.click()
+    time.sleep(1)
+    assert "Hello from TerminalMirror!" in terminalmirror_panel.terminal._terminal.output
+
+    # Collapsing and re-expanding the card must not lose the mirrored output:
+    # the buffer is replayed via redraw() on expand.
+    clears_before = terminalmirror_panel.terminal._terminal._clears
+    header = page.locator(".card-header").first
+    header.click()  # collapse
+    time.sleep(1)
+    header.click()  # expand
+    time.sleep(2)
+    assert terminalmirror_panel.terminal._terminal._clears == clears_before + 1
+    assert "Hello from TerminalMirror!" in terminalmirror_panel.terminal._terminal.output
+    assert page.locator(".xterm").first.is_visible()
+
+    server.stop()

--- a/tests/panels/terminalmirror/test_terminalmirror.py
+++ b/tests/panels/terminalmirror/test_terminalmirror.py
@@ -1,0 +1,154 @@
+"""Test cases for the Panelini terminalmirror panel."""
+
+import sys
+
+import panel as pn
+
+from panelini.panels.terminalmirror import TerminalMirror
+
+
+def test_creation():
+    """Test that a TerminalMirror panel can be created without redirecting."""
+    term = TerminalMirror(mirror=False)
+    assert isinstance(term, TerminalMirror)
+    assert isinstance(term.__panel__(), pn.widgets.Terminal)
+
+
+def test_write_returns_length():
+    """Test that write() returns the number of characters written."""
+    term = TerminalMirror(mirror=False)
+    assert term.write("hi") == 2
+
+
+def test_start_stop_restores_stdout():
+    """Test that start() redirects and stop() restores sys.stdout."""
+    original = sys.stdout
+    term = TerminalMirror(mirror=False)
+    try:
+        term.start()
+        assert sys.stdout is term
+    finally:
+        term.stop()
+    assert sys.stdout is original
+
+
+def test_context_manager_restores_stdout():
+    """Test that the context manager redirects inside and restores after."""
+    original = sys.stdout
+    with TerminalMirror(mirror=False) as term:
+        assert sys.stdout is term
+    assert sys.stdout is original
+
+
+def test_stop_is_idempotent_and_safe_when_not_active():
+    """Test that stop() is a no-op when redirection was never started."""
+    original = sys.stdout
+    term = TerminalMirror(mirror=False)
+    term.stop()
+    assert sys.stdout is original
+
+
+def test_start_is_idempotent():
+    """Test that calling start() twice does not lose the original stream."""
+    original = sys.stdout
+    term = TerminalMirror(mirror=False)
+    try:
+        term.start()
+        term.start()
+        assert sys.stdout is term
+        assert term._original_stdout is original
+    finally:
+        term.stop()
+    assert sys.stdout is original
+
+
+def test_nested_redirect_not_clobbered():
+    """Test that stop() leaves a redirect installed after start() untouched."""
+    original = sys.stdout
+    term = TerminalMirror(mirror=False)
+    term.start()
+    foreign = object()
+    sys.stdout = foreign  # type: ignore[assignment]
+    try:
+        term.stop()
+        assert sys.stdout is foreign
+    finally:
+        sys.stdout = original
+
+
+def test_print_is_mirrored():
+    """Test that print() reaches both the widget and the original stream."""
+    term = TerminalMirror(mirror=False)
+    try:
+        term.start()
+        print("mirrored line")
+    finally:
+        term.stop()
+    # After stop, the widget has buffered the written text.
+    assert "mirrored line" in term._terminal.output
+
+
+def test_redraw_preserves_output_and_signals_clear():
+    """redraw() replays the full buffer (clear + rewrite) without losing it."""
+    term = TerminalMirror(mirror=False)
+    term.write("alpha\n")
+    term.write("bravo\n")
+    output_before = term._terminal.output
+    clears_before = term._terminal._clears
+
+    term.redraw()
+
+    assert term._terminal.output == output_before
+    assert term._terminal._clears == clears_before + 1
+
+
+def test_redraw_empty_buffer_is_safe():
+    """redraw() on an empty terminal clears without writing anything."""
+    term = TerminalMirror(mirror=False)
+    term.redraw()
+    assert term._terminal.output == ""
+
+
+def test_bind_collapse_redraws_on_expand():
+    """bind_collapse() replays the buffer when the bound card is expanded."""
+    term = TerminalMirror(mirror=False)
+    card = pn.Card(term, collapsed=False)
+    term.bind_collapse(card)
+
+    term.write("kept line\n")
+    clears_before = term._terminal._clears
+
+    card.collapsed = True
+    card.collapsed = False
+
+    assert term._terminal._clears == clears_before + 1
+    assert "kept line" in term._terminal.output
+
+
+def test_bind_collapse_ignores_collapse():
+    """bind_collapse() does not redraw when the card is merely collapsed."""
+    term = TerminalMirror(mirror=False)
+    card = pn.Card(term, collapsed=False)
+    term.bind_collapse(card)
+
+    term.write("kept line\n")
+    clears_before = term._terminal._clears
+
+    card.collapsed = True
+
+    assert term._terminal._clears == clears_before
+
+
+def test_example_redraws_on_card_expand():
+    """The panelini example replays the buffer when the card is expanded."""
+    from examples.panels.terminalmirror.terminalmirror_panelini_min import card, terminalmirror_panel
+
+    term = terminalmirror_panel.terminal
+    term.write("persisted line\n")
+    clears_before = term._terminal._clears
+
+    card.collapsed = True
+    card.collapsed = False
+
+    assert term._terminal._clears == clears_before + 1
+    assert "persisted line" in term._terminal.output

--- a/uv.lock
+++ b/uv.lock
@@ -2583,7 +2583,7 @@ wheels = [
 
 [[package]]
 name = "panelini"
-version = "0.9.2"
+version = "0.9.3"
 source = { editable = "." }
 dependencies = [
     { name = "panel" },


### PR DESCRIPTION
Summary

- Adds `TerminalMirror`, a `pn.viewable.Viewer` that tees `sys.stdout` into a `pn.widgets.Terminal` widget while keeping the real console stream intact
- Collapse/expand buffer replay is auto-wired: importing the module patches `pn.Card.__init__` to detect any `TerminalMirror` in the constructor arguments (directly or nested in a `Viewer`) and call `bind_collapse` — no manual wiring needed
- `bind_collapse` is idempotent; `start()`/`stop()` and context manager for redirect control
- Fixes pydantic v1 `schema()` → v2 `model_json_schema()` deprecation in jsoneditor example