### PR TITLE
fix: make .content scroll vertically like .sidebar

### DIFF
--- a/src/panelini/main.css
+++ b/src/panelini/main.css
@@ -12,6 +12,7 @@
   background-size: cover;
   background-position: top;
   height: 100%;
+  overflow-y: auto;
 }
 
 .sidebar {


### PR DESCRIPTION
## Problem

The main content area `.content` is `height: 100%` with the wallpaper background, but - unlike `.sidebar` - has no `overflow-y`. When the main content is taller than the viewport (e.g. several stacked plots in a dashboard), it overflows the `.content` box and paints onto the plain page background below the wallpaper instead of scrolling.

## Fix

Add `overflow-y: auto` to `.content`, mirroring `.sidebar` (which already has it). The content now scrolls within the wallpaper-backed area; the wallpaper stays fixed.

## Verification

Reproduced in a dashboard with four stacked Bokeh plots taller than the viewport. Before: content spilled past the wallpaper onto white. After: `.content` is a scroll container (`scrollHeight > clientHeight`, `overflow-y: auto`), all plots reachable by scrolling, wallpaper covers the full visible area at every scroll position.