### PR TITLE
fix(wunderbaum): copy-drag badge, and copies the application actually applies

### DIFF
--- a/examples/panels/wunderbaum/dnd_selection_playground.py
+++ b/examples/panels/wunderbaum/dnd_selection_playground.py
@@ -18,10 +18,14 @@ Three treegrids side by side, same source, different selection setup:
 
 Every tree event is appended to the log at the bottom with its full key
 payload, so single vs. multi drags and same-tree vs. cross-tree drops can be
-told apart. Ctrl+drag copies instead of moving (Option on macOS).
+told apart. Ctrl+drag copies instead of moving (Option on macOS); the panel
+reports such a drop and leaves the tree untouched, so ``_perform_copy`` below
+inserts the duplicates, which is the application's job in a real app.
 """
 
 import copy
+import itertools
+import json
 
 import panel as pn
 
@@ -87,9 +91,75 @@ def _log(tree_id: str, name: str, params: dict) -> None:
     event_log.object = "\n".join(log_lines)
 
 
+_copy_counter = itertools.count(1)
+
+
+def _locate(nodes: list[dict], key: str) -> tuple[list[dict], int] | None:
+    """The child list holding *key* and the index of *key* within it."""
+    for i, node in enumerate(nodes):
+        if node["key"] == key:
+            return nodes, i
+        found = _locate(node.get("children", []), key)
+        if found:
+            return found
+    return None
+
+
+def _rekey(node: dict, suffix: str) -> None:
+    """Give a cloned subtree fresh keys, and drop any selection it carried."""
+    node["key"] = f"{node['key']}{suffix}"
+    node.pop("selected", None)
+    for child in node.get("children", []):
+        _rekey(child, suffix)
+
+
+def _perform_copy(tree: Wunderbaum, params: dict) -> None:
+    """Insert the copies the panel reported but deliberately did not make.
+
+    On a copy-drag the panel emits the event and puts the dragged node back
+    where it was, leaving the actual duplication to the application - keys are
+    the app's to mint. This is that half, for one plausible key scheme.
+    """
+    # Round-trip through JSON, not copy.deepcopy. In a live session
+    # ``tree.source`` is a Bokeh property wrapper that holds back-references to
+    # the document, so deepcopying it walks into the server's IOLoop and raises
+    # RuntimeError. The source is JSON on the wire anyway.
+    source = json.loads(json.dumps(tree.source))
+    located = _locate(source, params["targetKey"])
+    if located is None:
+        return
+    siblings, index = located
+    region = params["region"]
+
+    if region in ("over", "appendChild", "prependChild"):
+        target_node = siblings[index]
+        dest = target_node.setdefault("children", [])
+        at = 0 if region == "prependChild" else len(dest)
+        target_node["expanded"] = True
+    else:
+        dest = siblings
+        at = index if region == "before" else index + 1
+
+    for offset, key in enumerate(params.get("sourceKeys", [])):
+        found = _locate(source, key)
+        if found is None:
+            continue
+        original_siblings, original_index = found
+        clone = copy.deepcopy(original_siblings[original_index])
+        clone["title"] = f"{clone['title']} (copy)"
+        _rekey(clone, f"-c{next(_copy_counter)}")
+        dest.insert(at + offset, clone)
+
+    tree.source = source
+
+
 def _callback(tree_id: str):
     def handler(name: str, params: dict) -> None:
         _log(tree_id, name, params)
+        if name == "drop" and params.get("copy"):
+            tree = TREES.get(tree_id)
+            if tree is not None:
+                _perform_copy(tree, params)
 
     return handler
 
@@ -108,6 +178,9 @@ def _make_tree(tree_id: str, options: dict) -> Wunderbaum:
 tree_multi = _make_tree("multi", {"dnd": True, "checkbox": True, "selectMode": "multi"})
 tree_hier = _make_tree("hier", {"dnd": True, "checkbox": True, "selectMode": "hier"})
 tree_plain = _make_tree("plain", {"dnd": True, "selectMode": "multi"})
+
+# Looked up by id inside the event handler, which is built before the trees are.
+TREES: dict[str, Wunderbaum] = {"multi": tree_multi, "hier": tree_hier, "plain": tree_plain}
 
 
 def _panel(title: str, subtitle: str, tree: Wunderbaum) -> pn.Column:
@@ -181,6 +254,23 @@ inserts after, the middle half drops into the row.
     the folder and lands above it at root level. This used to be refused.
 15. Drag `File 1` onto the middle of `Folder A`. Nothing happens - it is already
     in that folder, so there is no move to make.
+
+### Copy
+
+Ctrl+drag copies instead of moving, Option+drag on macOS. Hold the key before
+you start dragging and the cursor badge turns from move to copy.
+
+16. Ctrl+drag `File 3` onto `Folder B`. `File 3 (copy)` appears there and the
+    original stays put.
+17. Check `File 1` and `File 2`, then ctrl+drag `File 1` onto the top edge of
+    `File 4`. Both copies land above it, in order.
+18. Ctrl+drag `Folder A` onto `Folder B`. The children come along, each with a
+    fresh key.
+
+The panel itself never inserts these copies. It reports the drop with
+`copy: true`, `sourceKeys`, `region` and `newParentNodeId`, then puts the
+dragged node back - minting keys is the application's job. `_perform_copy` in
+this file is one way to do that half.
 
 **Across trees**, drag from any tree into another. The receiver emits
 `externalDrop` with `source_keys` and moves nothing on its own.

--- a/src/panelini/panels/wunderbaum/vue/dist/wunderbaum_vue.mjs
+++ b/src/panelini/panels/wunderbaum/vue/dist/wunderbaum_vue.mjs
@@ -8546,7 +8546,7 @@ const rf = (t, e) => {
         preventVoidMoves: !1,
         dragStart: (c) => {
           var f;
-          this._dragOrigParent = c.node.parent, this._dragActive = !0, this._selectAfterDrag = c.node.isSelected() ? null : c.node.key;
+          this._dragOrigParent = c.node.parent, this._dragOrigNext = c.node.getNextSibling(), this._dragActive = !0, this._selectAfterDrag = c.node.isSelected() ? null : c.node.key;
           const a = this.getDragKeys(c.node);
           return (f = c.event) != null && f.dataTransfer && (c.event.dataTransfer.setData("text/plain", a.join(`
 `)), c.event.dataTransfer.setData(Un, JSON.stringify(a)), c.event.dataTransfer.setData(go, this.treeId || ""), c.event.dataTransfer.effectAllowed = "copyMove"), this.sendEvent("dragStart", { key: c.node.key, keys: a }), !0;
@@ -8575,7 +8575,7 @@ const rf = (t, e) => {
             const V = b === "over" || b === "appendChild" || b === "prependChild" ? f : f.parent;
             this.sendEvent("drop", {
               sourceKey: a.key,
-              sourceKeys: p.map((I) => I.key),
+              sourceKeys: p.map((W) => W.key),
               targetKey: f.key,
               region: b,
               copy: !0,
@@ -8583,8 +8583,8 @@ const rf = (t, e) => {
               copiedNodeIds: p.map(m),
               newParentNodeId: ((g = V == null ? void 0 : V.data) == null ? void 0 : g.node_id) || (V == null ? void 0 : V.key) || null
             });
-            const M = this._dragOrigParent;
-            M && a.parent !== M && a.moveTo(M, "appendChild"), this.emitSource();
+            const M = this._dragOrigParent, I = this._dragOrigNext;
+            M && (I && I.parent === M ? a.moveTo(I, "before") : a.moveTo(M, "appendChild"));
           } else {
             let T = f, V = b;
             for (const I of p)

--- a/src/panelini/panels/wunderbaum/vue/dist/wunderbaum_vue.mjs
+++ b/src/panelini/panels/wunderbaum/vue/dist/wunderbaum_vue.mjs
@@ -8552,10 +8552,15 @@ const rf = (t, e) => {
 `)), c.event.dataTransfer.setData(Un, JSON.stringify(a)), c.event.dataTransfer.setData(go, this.treeId || ""), c.event.dataTransfer.effectAllowed = "copyMove"), this.sendEvent("dragStart", { key: c.node.key, keys: a }), !0;
         },
         dragEnter: (c) => c.node === c.sourceNode ? !1 : ["before", "after", "over"],
-        dragOver: (c) => {
-          var a;
-          (a = c.event) != null && a.dataTransfer && (c.event.dataTransfer.dropEffect = "move");
-        },
+        // No dragOver callback on purpose. Wunderbaum sets
+        // dataTransfer.dropEffect from its own guessDropEffect right before
+        // calling us, and that guess is already platform-correct: Option
+        // copies on macOS, Ctrl elsewhere. Overwriting it here is what used
+        // to show a move badge during a copy. Nothing in the library cancels
+        // a drop over the value, so leaving it alone is safe.
+        //
+        // The copy decision itself still comes from our own key tracking,
+        // because modifier flags are not reliable on the drop event.
         drop: (c) => {
           var g, N;
           const a = c.sourceNode, f = c.node, b = this.effectiveRegion(c.suggestedDropMode, f), u = this._copyPressed || !!window.__wbForceCopy;
@@ -8667,7 +8672,7 @@ const rf = (t, e) => {
       }), t.addEventListener("dragleave", (i) => {
         t.style.border = "1px solid #ddd";
       }), t.addEventListener("dragover", (i) => {
-        n(i) && (i.preventDefault(), e(i) && (i.dataTransfer.dropEffect = "move"));
+        n(i) && (i.preventDefault(), e(i) && (i.dataTransfer.dropEffect = this._copyPressed ? "copy" : "move"));
       }), t.addEventListener("dragend", () => {
         var r, s;
         this._dragActive = !1, t.style.border = "1px solid #ddd";

--- a/src/panelini/panels/wunderbaum/vue/src/wunderbaum.vue
+++ b/src/panelini/panels/wunderbaum/vue/src/wunderbaum.vue
@@ -310,8 +310,11 @@ export default {
           // the moves that genuinely change nothing instead.
           preventVoidMoves: false,
           dragStart: (e) => {
-            // Save original parent - needed to undo auto-move on Ctrl+copy
+            // Save the original slot - needed to undo auto-move on Ctrl+copy.
+            // The next sibling pins the index, so the undo can put the node
+            // back exactly where it was instead of appending it last.
             this._dragOrigParent = e.node.parent;
+            this._dragOrigNext = e.node.getNextSibling();
             // Mark this tree as the drag origin so its own container-level
             // listeners can tell a same-tree drag from a cross-tree one.
             // dataTransfer is in protected mode during dragover, so the
@@ -388,14 +391,25 @@ export default {
                 copiedNodeIds: dragNodes.map(nodeId),
                 newParentNodeId: dropParent?.data?.node_id || dropParent?.key || null,
               });
-              // Undo wunderbaum's auto-move: source must stay in original
-              // place. Only e.sourceNode is auto-moved, the rest of the
-              // selection was never touched.
+              // Undo wunderbaum's auto-move: the source must stay in its
+              // original slot. Only e.sourceNode is auto-moved, the rest of
+              // the selection was never touched.
+              //
+              // Restore the index, not just the parent - a drop inside the
+              // node's own parent reorders it without reparenting it. Once the
+              // node is back, the client tree is identical to the one Python
+              // already holds, so there is nothing to emit. Emitting here
+              // would race the drop event above and overwrite whatever copy
+              // the application inserted in its callback.
               const origParent = this._dragOrigParent;
-              if (origParent && sourceNode.parent !== origParent) {
-                sourceNode.moveTo(origParent, 'appendChild');
+              const origNext = this._dragOrigNext;
+              if (origParent) {
+                if (origNext && origNext.parent === origParent) {
+                  sourceNode.moveTo(origNext, 'before');
+                } else {
+                  sourceNode.moveTo(origParent, 'appendChild');
+                }
               }
-              this.emitSource();
             } else {
               // 'after' and 'prependChild' have to re-anchor on the node just
               // moved, or a multi-node drop lands in reverse order. 'before'

--- a/src/panelini/panels/wunderbaum/vue/src/wunderbaum.vue
+++ b/src/panelini/panels/wunderbaum/vue/src/wunderbaum.vue
@@ -347,13 +347,15 @@ export default {
             if (e.node === e.sourceNode) return false;
             return ['before', 'after', 'over'];
           },
-          dragOver: (e) => {
-            // Ctrl changes dropEffect to 'copy' on Windows, which wunderbaum
-            // rejects. Force 'move' so the drop fires; we track Ctrl separately.
-            if (e.event?.dataTransfer) {
-              e.event.dataTransfer.dropEffect = 'move';
-            }
-          },
+          // No dragOver callback on purpose. Wunderbaum sets
+          // dataTransfer.dropEffect from its own guessDropEffect right before
+          // calling us, and that guess is already platform-correct: Option
+          // copies on macOS, Ctrl elsewhere. Overwriting it here is what used
+          // to show a move badge during a copy. Nothing in the library cancels
+          // a drop over the value, so leaving it alone is safe.
+          //
+          // The copy decision itself still comes from our own key tracking,
+          // because modifier flags are not reliable on the drop event.
           drop: (e) => {
             const sourceNode = e.sourceNode;
             const targetNode = e.node;
@@ -584,9 +586,10 @@ export default {
         if (isAcceptable(e)) {
           e.preventDefault();
           if (isExternalNodeDrag(e)) {
-            // Ctrl changes dropEffect to 'copy' on Windows, which cancels the
-            // drop. Force 'move', matching the internal dragOver handler.
-            e.dataTransfer.dropEffect = 'move';
+            // A cross-tree drag never enters wunderbaum's dnd extension, so
+            // nothing sets the badge for us here. Mirror what wunderbaum would
+            // show for a same-tree drag.
+            e.dataTransfer.dropEffect = this._copyPressed ? 'copy' : 'move';
           }
         }
       });


### PR DESCRIPTION
Two separate bugs in the copy-drag path. Either one alone makes a copy-drag look broken.

## 1. Move badge shown during a copy

Closes https://github.com/opensemanticworld/panelini/issues/53

The wrapper forced `dataTransfer.dropEffect = 'move'` on every dragover tick, so a copy-drag showed the move cursor on every platform. The stated reason ("Ctrl changes dropEffect to 'copy' on Windows, which wunderbaum rejects") does not hold: the drop branch at `wunderbaum.esm.js:2419-2440` never reads `dropEffect`, and the library forces it to `"none"` only in the `preventVoidMoves` / `preventRecursion` / `preventSameParent` guards.

The overwrite also landed between wunderbaum's own guess and the point where it records `lastDropEffect`, so it clobbered the `suggestedDropEffect` reported on the drop event.

- drop the `dragOver` callback and let `_guessDropEffect` stand, which is already platform-correct (Option copies on macOS, Ctrl elsewhere)
- in the cross-tree DOM listener, which sits outside wunderbaum's dnd extension, set the effect from the wrapper's own `_copyPressed`

## 2. The client's source echo overwrote the application's copy

On a copy-drop the panel emits the event and deliberately does not duplicate anything, leaving key minting to the application. Seven lines later it called `emitSource()` on a `setTimeout(0)`, shipping the client's tree back to Python. Both messages leave in the same tick, so Python applied the application's copy and then the client's un-copied echo overwrote it. The panel invited the app to perform the copy, then discarded the result.

That `emitSource()` was not gratuitous: the undo used `moveTo(origParent, 'appendChild')`, which appends, so a node that was not last came back in a different slot and Python had to be told.

- record the original next sibling at `dragStart` and restore the exact index, so the client tree needs no re-sync
- restore unconditionally, since a drop inside the node's own parent reorders without reparenting and the old `parent !== origParent` guard skipped that case
- remove the `emitSource()` from the copy branch

## Playground

`examples/panels/wunderbaum/dnd_selection_playground.py` now materializes the copies it reports, so a copy-drag is visible instead of log-only. Instructions gained a Copy section, cases 16-18.

It builds its plain working copy with `json.loads(json.dumps(...))` rather than `copy.deepcopy`. In a live session `tree.source` is a Bokeh property wrapper holding back-references to the document, and deepcopying it walks into the server's tornado IOLoop and raises `RuntimeError`.

## Verification

- full wunderbaum suite: 70 passed, 1 xfailed, unchanged from `stage`
- end to end against the running playground with the repo's own `drag()` helper: `File 1 (copy)` appears as the last child of Folder B and the original stays in Folder A at its original index
- cursor badge is not assertable from Playwright, so it was checked by hand in the playground

Not reproduced: in headless Chromium the real Ctrl key still yields a move in the playground, while `test_dnd_copy_with_real_key` passes. The keydown reaches `document` with `ctrlKey: true`, and a blur clearing the flag, `initTree` re-running, and a re-mount race were each tested and ruled out. Real browsers report `copy: True` correctly, so this reads as a harness artifact.
